### PR TITLE
Suggest use of JSON.stringify() in response decoder

### DIFF
--- a/public/responsedecoder/index.html
+++ b/public/responsedecoder/index.html
@@ -108,6 +108,13 @@
               <code>navigator.credentials.get()</code>
               below.
               <code>ArrayBuffer</code> values should be encoded into base64url strings.
+              <span class="fw-bold">
+                (Hint: Try passing a WebAuthn API response into
+                <a href="https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/toJSON#examples" target="_blank">
+                  <code>JSON.stringify()</code>
+                </a>
+                and then pasting the output below.)
+              </span>
             </p>
 
             <!-- JSON input -->

--- a/public/responsedecoder/script.js
+++ b/public/responsedecoder/script.js
@@ -70,7 +70,7 @@ function showDecodedOutput(responseType, decodedResponse) {
 }
 
 /**
- * @param {string} code The WebAuthn response being parsed
+ * @param {string} rawCredential The WebAuthn response being parsed
  * @returns void
  */
 function decodeResponse(rawCredential) {

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
         <loc>https://tools.passkeys.dev/</loc>
-        <lastmod>2026-01-27T17:54:12.213Z</lastmod>
+        <lastmod>2026-01-27T20:35:59.211Z</lastmod>
     </url>
     <url>
         <loc>https://tools.passkeys.dev/featuredetect</loc>
@@ -14,6 +14,6 @@
     </url>
     <url>
         <loc>https://tools.passkeys.dev/responsedecoder</loc>
-        <lastmod>2026-01-27T17:54:12.207Z</lastmod>
+        <lastmod>2026-02-02T15:41:47.466Z</lastmod>
     </url>
 </urlset>


### PR DESCRIPTION
This PR adds a suggestion to the Response Decoder tool to use PublicKeyCredential's JSON serialization support via `JSON.stringify()` to get to a representation of a WebAuthn API that can be pasted into the text box:

<img width="676" height="185" alt="Screenshot 2026-02-02 at 4 42 31 PM" src="https://github.com/user-attachments/assets/af33d3af-d6f4-4540-8243-f6b7412c9095" />
