### PR TITLE
Response Decoder: Auto-prettify JSON on paste

### DIFF
--- a/public/responsedecoder/script.js
+++ b/public/responsedecoder/script.js
@@ -30,6 +30,23 @@ flaskTextarea.addEventListener('focus', () => {
   flaskTextarea.select();
 });
 
+/**
+ * Take a pasted JSON response and try to prettify it
+ */
+flaskTextarea.addEventListener('paste', (event) => {
+  try {
+    const pasted = event.clipboardData.getData("text");
+    const pastedJSON = JSON.parse(pasted);
+    const prettifiedJSON = JSON.stringify(pastedJSON, null, 2);
+    flask.updateCode(prettifiedJSON);
+
+    // Prevent the original content from being appended to the prettified JSON
+    event.preventDefault();
+  } catch (err) {
+    // Allow the textarea to behave as usual
+  }
+});
+
 // Attempt to parse whatever was just pasted in
 flask.onUpdate((code) => {
   resetUI();


### PR DESCRIPTION
This PR adds an automatic attempt to prettify the JSON WebAuthn response when it is pasted into the text box.

For sake of comparison, here's how the experience of pasting in the following `JSON.stringify()`'d WebAuthn API response changes with this PR:

```
{"authenticatorAttachment":"platform","clientExtensionResults":{},"id":"dA7bc-lgyFssbewmhGPEB8sjXs-g0ulzf0yddaRA834","rawId":"dA7bc-lgyFssbewmhGPEB8sjXs-g0ulzf0yddaRA834","response":{"authenticatorData":"dKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvAFAAAAAA","clientDataJSON":"eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiQUFBQUFBQUFBQUFBQUFBQUFBQUFBQSIsIm9yaWdpbiI6Imh0dHBzOi8vd2ViYXV0aG4uaW8iLCJjcm9zc09yaWdpbiI6ZmFsc2V9","signature":"MEUCIGzYH6mhbNhRvt_B5oNEsYKU2fnwkbkIxoz-zrWjln5RAiEArWmE3mARMcxGn_IuJ-9R0ECnSxAD-vsYu1Sp_6rH7WY","userHandle":"d2ViYXV0aG5pby1tbWlsbGVy"},"type":"public-key"}
```

## Before

<img width="686" height="585" alt="Screenshot 2026-02-04 at 12 05 16 PM" src="https://github.com/user-attachments/assets/4f282a9d-e010-440e-9686-54820971706f" />

## After

<img width="676" height="597" alt="Screenshot 2026-02-04 at 12 05 29 PM" src="https://github.com/user-attachments/assets/0e84aa02-92c6-4314-aac0-8c1c227a4030" />