### PR TITLE
Feature Detect: Fix UA Parser loading issue

### DIFF
--- a/src/featuredetect/index.njk
+++ b/src/featuredetect/index.njk
@@ -203,10 +203,17 @@ extra_scripts:
 </div>
 
 <script>
-    const uap = new UAParser();
-    const result = uap.getResult();
-    const friendlyName = `${result.browser.name} ${result.browser.major}` || "Unknown Client";
-    document.getElementById("clientShortName").textContent = friendlyName;
+    window.addEventListener('DOMContentLoaded', () => {
+        try {
+            const uap = new UAParser();
+            const result = uap.getResult();
+            const friendlyName = `${result.browser.name} ${result.browser.major}` || "Unknown Client";
+            document.getElementById("clientShortName").textContent = friendlyName;
+        } catch (e) {
+            console.error("UA Parser error:", e);
+            document.getElementById("clientShortName").textContent = "Unknown Client";
+        }
+    });
 
     function updateStyle(id, type) {
         var pillElement = document.getElementById(`pill-${id}`);


### PR DESCRIPTION
UA Parser wasn't loading correctly, and also was blocking the rest of the feature detection logic.

1. Wraps UA Parser in a try/catch to prevent the rest of the feature detection from working
2. The parser logic now waits until the DOM is ready and external scripts have been processed before doing device detection.